### PR TITLE
add check to detect OS (Debian) where su-bruteforce cannot be used

### DIFF
--- a/suBF.sh
+++ b/suBF.sh
@@ -28,6 +28,11 @@ if ! [ "$USER" ]; then printf "$help"; exit 0; fi
 
 if ! [[ -p /dev/stdin ]] && ! [ $WORDLIST = "-" ] && ! [ -f "$WORDLIST" ]; then echo "Wordlist ($WORDLIST) not found!"; exit 0; fi
 
+if [[ `echo '' | timeout $TIMEOUTPROC su $USER -c whoami 2>&1` == "su: must be run from a terminal" ]]; then 
+  echo "  Error: su must be run from a terminal, su-bruteforce cannot be used against this OS"
+  exit 0
+fi
+
 C=$(printf '\033')
 
 su_try_pwd (){


### PR DESCRIPTION
Hello, I noticed during a CTF that su-bruteforce didn't work for some reason.
After digging a bit, it's because of the OS.
su from Debian will not authorize the use of su without a terminal
![image](https://github.com/carlospolop/su-bruteforce/assets/71428793/78fb7254-1ad1-4157-80f8-ce800c6560f3)
I found the relevant code here:
https://sources.debian.org/src/shadow/1:4.5-1.1/src/su.c/?hl=720#L720
I think this problem is still relevant
https://sources.debian.org/src/shadow/1%3A4.8.1-1/src/su.c/#L721

Since the current code discard the stderr, the current behavior is a false negative.
```bash
  trysu=`echo "$PASSWORDTRY" | timeout $TIMEOUTPROC su $USER -c whoami 2>/dev/null` 
  if [ "$trysu" ]; then
    echo "  You can login as $USER using password: $PASSWORDTRY" | sed "s,.*,${C}[1;31;103m&${C}[0m,"
    exit 0;
  fi
```

So I added a check, a message and stop the script in case it can't be used against this type of OS

PS: the relevant CTF
https://tryhackme.com/room/jackofalltrades
Debian 3.16.7

EDIT:
I noticed that linpeas already contains a check to see if su exists: https://github.com/carlospolop/PEASS-ng/pull/363
and a check on the "must be run from a terminal" that already existed

So I ported them instead.